### PR TITLE
go: add reflexive closure option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build-go:
-	go fmt
+	gofmt -w .
 	go build
 	go install
 	go test ./tests

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -22,18 +22,35 @@ func dependencies(cmd *cobra.Command, targets []string) {
 	jsonData := ReadFile(filePath)
 	adjacencyList := loadJsonFile(jsonData)
 	var deps []string
-	transitive, _ := cmd.Flags().GetBool("transitive")
 
-	if transitive == true {
+	transitive, _ := cmd.Flags().GetBool("transitive")
+	if transitive {
 		deps = getDepsTransitive(adjacencyList, targets)
 	} else {
 		deps = getDepsDirect(adjacencyList, targets)
+	}
+
+	reflexive, _ := cmd.Flags().GetBool("reflexive")
+	if reflexive {
+		reflexiveTargets := getReflexiveTargets(targets, adjacencyList)
+		deps = append(deps, reflexiveTargets...)
 	}
 	slices.Sort(deps)
 	deps = slices.Compact(deps)
 	output := strings.Join(deps, "\n")
 	fmt.Fprintln(cmd.OutOrStdout(), output)
 
+}
+
+func getReflexiveTargets(targets []string, adjacencyList map[string][]string) []string {
+	var candidates []string
+	for _, target := range targets {
+		_, exists := adjacencyList[target]
+		if exists {
+			candidates = append(candidates, target)
+		}
+	}
+	return candidates
 }
 
 func getDepsDirect(adjacencyList map[string][]string, targets []string) []string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,6 @@ var dependenciesCmd = &cobra.Command{
 
 // JSON file with the dependency graph represented as an adjacency list
 var dg string
-var target string
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the RootCmd.
@@ -50,6 +49,7 @@ func init() {
 	RootCmd.AddCommand(dependenciesCmd)
 	dependenciesCmd.Flags().StringVar(&dg, "dg", "", "JSON file with the dependency graph represented as an adjacency list")
 	dependenciesCmd.Flags().BoolP("transitive", "", false, "Get transitive dependencies")
+	dependenciesCmd.Flags().BoolP("reflexive", "", false, "Include input targets in the output")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -285,3 +285,64 @@ func TestDependenciesTransitive(t *testing.T) {
 		buf.Reset()
 	}
 }
+
+func TestDependenciesReflexiveClosure(t *testing.T) {
+
+	var buf bytes.Buffer
+	cmd.RootCmd.SetOut(&buf)
+	cmd.RootCmd.SetErr(&buf)
+
+	cases := []struct {
+		input    []byte
+		expected []string
+		targets  []string
+	}{
+		// base case
+		{
+			input: []byte(`
+			{
+				"foo.py": [
+					"spam.py"
+				],
+				"bar.py": [
+					"eggs.py"
+				]
+			}		
+			`),
+			expected: []string{"bar.py", "eggs.py", "foo.py", "spam.py"},
+			targets:  []string{"foo.py", "bar.py"},
+		},
+		// empty dependencies with a non-existing target
+		{
+			input: []byte(`
+			{
+				"foo.py": []
+			}		
+			`),
+			expected: []string{"foo.py"},
+			targets:  []string{"foo.py", "bar.py"},
+		},
+		// duplicate input targets
+		{
+			input: []byte(`
+			{
+				"foo.py": ["bar.py"]
+			}		
+			`),
+			expected: []string{"bar.py", "foo.py"},
+			targets:  []string{"foo.py", "foo.py"},
+		},
+	}
+
+	for _, testCase := range cases {
+		// mocking function that reads a file from disk
+		cmd.ReadFile = func(filePath string) []byte {
+			return testCase.input
+		}
+		cmd.RootCmd.SetArgs(append([]string{"dependencies", "--reflexive", "--dg=dg.json"}, testCase.targets...))
+		cmd.RootCmd.Execute()
+		actualOutput := strings.Split(buf.String(), "\n")[:len(testCase.expected)]
+		assert.Equal(t, testCase.expected, actualOutput)
+		buf.Reset()
+	}
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -312,7 +312,7 @@ func TestDependenciesReflexiveClosure(t *testing.T) {
 			expected: []string{"bar.py", "eggs.py", "foo.py", "spam.py"},
 			targets:  []string{"foo.py", "bar.py"},
 		},
-		// empty dependencies with a non-existing target
+		// empty dependencies with a non-existing target (case 1)
 		{
 			input: []byte(`
 			{
@@ -322,6 +322,16 @@ func TestDependenciesReflexiveClosure(t *testing.T) {
 			expected: []string{"foo.py"},
 			targets:  []string{"foo.py", "bar.py"},
 		},
+		// empty dependencies with a non-existing target (case 2)
+		{
+			input: []byte(`
+			{
+				"foo.py": []
+			}		
+			`),
+			expected: []string{},
+			targets:  []string{"bar.py"},
+		},		
 		// duplicate input targets
 		{
 			input: []byte(`


### PR DESCRIPTION
With 

```
{
    "foo.py": [
        "bar.py",
        "baz.py"
    ],
    "spam.py": [
        "ham.py",
        "eggs.py",        
        "bar.py"
    ]
}
```

run

```
$ go run main.go dependencies --reflexive --dg="examples/dg-real.json" foo.py spam.py
bar.py
baz.py
eggs.py
foo.py
ham.py
spam.py
```
