### PR TITLE
go: add dependents to metrics

### DIFF
--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -14,9 +14,12 @@ var Dependencies = dependencies
 List dependencies for given targets.
 */
 func dependencies(filePath string, targets []string, transitive bool, reflexive bool,
-	depth int, readFile ReadFileFunc) []string {
-	jsonData := readFile(filePath)
-	adjacencyList := loadJsonFile(jsonData)
+	depth int, readFile ReadFileFunc) ([]string, error) {
+	jsonData, err := readFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	adjacencyList, err := loadJsonFile(jsonData)
 	var deps []string
 
 	if transitive {
@@ -31,7 +34,7 @@ func dependencies(filePath string, targets []string, transitive bool, reflexive 
 	}
 	slices.Sort(deps)
 	deps = slices.Compact(deps)
-	return deps
+	return deps, nil
 
 }
 

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -84,5 +84,7 @@ func getDepsTransitive(adjacencyList map[string][]string, targets []string, dept
 	for _, target := range targets {
 		getDeps(target, 1)
 	}
+	slices.Sort(deps)
+	deps = slices.Compact(deps)
 	return deps
 }

--- a/cmd/dependencies_test.go
+++ b/cmd/dependencies_test.go
@@ -131,12 +131,15 @@ func TestDependenciesDirect(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := false
 		reflexive := false
-		result := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }
@@ -255,12 +258,15 @@ func TestDependenciesTransitive(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := true
 		reflexive := false
-		result := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }
@@ -316,12 +322,15 @@ func TestDependenciesReflexiveClosure(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := false
 		reflexive := true
-		result := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }
@@ -406,12 +415,15 @@ func TestDependenciesDepth(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := true
 		reflexive := false
-		result := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependencies("mock.json", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }

--- a/cmd/dependents.go
+++ b/cmd/dependents.go
@@ -32,15 +32,28 @@ List dependents for given targets. If the reverse dependency graph is provided,
 it's used, otherwise a dependency graph is reversed first.
 */
 func dependents(filePathDg string, filePathDgReverse string, targets []string, transitive bool, reflexive bool,
-	depth int, DefaultReadFile ReadFileFunc) []string {
+	depth int, DefaultReadFile ReadFileFunc) ([]string, error) {
 	var adjacencyList AdjacencyList
 
 	if filePathDgReverse != "" {
-		jsonData := DefaultReadFile(filePathDgReverse)
-		adjacencyList = loadJsonFile(jsonData)
+		jsonData, err := DefaultReadFile(filePathDgReverse)
+		if err != nil {
+			return nil, err
+		}
+		adjacencyList, err = loadJsonFile(jsonData)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		jsonData := DefaultReadFile(filePathDg)
-		adjacencyList = reverseAdjacencyLists(loadJsonFile(jsonData))
+		jsonData, err := DefaultReadFile(filePathDg)
+		if err != nil {
+			return nil, err
+		}
+		adjacencyList, err = loadJsonFile(jsonData)
+		if err != nil {
+			return nil, err
+		}
+		adjacencyList = reverseAdjacencyLists(adjacencyList)
 	}
 
 	var rdeps []string
@@ -56,5 +69,5 @@ func dependents(filePathDg string, filePathDgReverse string, targets []string, t
 	}
 	slices.Sort(rdeps)
 	rdeps = slices.Compact(rdeps)
-	return rdeps
+	return rdeps, nil
 }

--- a/cmd/dependents_test.go
+++ b/cmd/dependents_test.go
@@ -122,13 +122,16 @@ func TestDependentsDirect(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := false
 		reflexive := false
 		// use dependency graph to be reversed
-		result := dependents("mock-dg.json", "", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependents("mock-dg.json", "", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }
@@ -156,12 +159,15 @@ func TestDependentsTransitiveReflexiveClosure(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		transitive := true
 		reflexive := true
-		result := dependents("mock-dg.json", "", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		result, err := dependents("mock-dg.json", "", testCase.targets, transitive, reflexive, testCase.depth, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, testCase.expected, result)
 	}
 }

--- a/cmd/dg.go
+++ b/cmd/dg.go
@@ -9,23 +9,23 @@ import (
 )
 
 // Function type to be used for reading files
-type ReadFileFunc func(filePath string) []byte
+type ReadFileFunc func(filePath string) ([]byte, error)
 
 type AdjacencyList map[string][]string
 
-var DefaultReadFile = func(filePath string) []byte {
+var DefaultReadFile = func(filePath string) ([]byte, error) {
 	jsonData, readingFileError := os.ReadFile(filePath)
 	if readingFileError != nil {
-		panic(readingFileError)
+		return nil, readingFileError
 	}
-	return jsonData
+	return jsonData, nil
 }
 
-func loadJsonFile(jsonData []byte) AdjacencyList {
+func loadJsonFile(jsonData []byte) (AdjacencyList, error) {
 	var adjacencyList AdjacencyList
 	loadingJsonError := json.Unmarshal(jsonData, &adjacencyList)
 	if loadingJsonError != nil {
-		panic(loadingJsonError)
+		return nil, loadingJsonError
 	}
-	return adjacencyList
+	return adjacencyList, nil
 }

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -44,6 +44,15 @@ func getMetricDependenciesDirect(adjacencyList AdjacencyList) GenericMapStringTo
 	for key, deps := range adjacencyList {
 		depsCount[key] = len(deps)
 	}
+	// set count to 0 for nodes that were not present as keys in the adjacency list
+	// (i.e. they are only dependencies of some nodes and do not depend on anything)
+	for _, deps := range adjacencyList {
+		for _, dep := range deps {
+			if _, isKey := adjacencyList[dep]; !isKey {
+				depsCount[dep] = 0
+			}
+		}
+	}
 	return depsCount
 }
 
@@ -63,6 +72,15 @@ func getMetricDependenciesTransitive(adjacencyList AdjacencyList) GenericMapStri
 			visited[dep] = len(transitiveDeps)
 		}
 	}
+	// set count to 0 for nodes that were not present as keys in the adjacency list
+	// (i.e. they are only dependencies of some nodes and do not depend on anything)
+	for _, deps := range adjacencyList {
+		for _, dep := range deps {
+			if _, isKey := adjacencyList[dep]; !isKey {
+				depsCount[dep] = 0
+			}
+		}
+	}
 	return depsCount
 }
 
@@ -74,6 +92,8 @@ Produce data for given metrics.
 */
 func metrics(filePathDg string, filePathDgReverse string, metricsItems []string, readFile ReadFileFunc) []byte {
 	var adjacencyList AdjacencyList
+	var adjacencyListReverse AdjacencyList
+
 	report := make(map[string]map[string]interface{})
 	// use dependencies adjacency list as is
 	if slices.Contains(metricsItems, MetricDependenciesDirect) || slices.Contains(metricsItems, MetricDependenciesTransitive) {
@@ -84,10 +104,18 @@ func metrics(filePathDg string, filePathDgReverse string, metricsItems []string,
 	if slices.Contains(metricsItems, MetricReverseDependenciesDirect) || slices.Contains(metricsItems, MetricReverseDependenciesTransitive) {
 		if filePathDgReverse != "" {
 			jsonData := readFile(filePathDgReverse)
-			adjacencyList = loadJsonFile(jsonData)
+			adjacencyListReverse = loadJsonFile(jsonData)
 		} else {
 			jsonData := readFile(filePathDg)
-			adjacencyList = reverseAdjacencyLists(loadJsonFile(jsonData))
+			adjacencyListTemp := loadJsonFile(jsonData)
+			adjacencyListReverse = reverseAdjacencyLists(adjacencyListTemp)
+			// extending the map with the nodes that had no dependencies (e.g. {"foo": []} as "foo" won't be in reverse adjacency list
+			// if no one depends on "foo")
+			for key, deps := range adjacencyListTemp {
+				if len(deps) == 0 {
+					adjacencyListReverse[key] = []string{}
+				}
+			}
 		}
 	}
 
@@ -105,10 +133,10 @@ func metrics(filePathDg string, filePathDgReverse string, metricsItems []string,
 			report[metric] = getMetricDependenciesTransitive(adjacencyList)
 
 		case MetricReverseDependenciesDirect:
-			report[metric] = getMetricDependenciesDirect(adjacencyList)
+			report[metric] = getMetricDependenciesDirect(adjacencyListReverse)
 
 		case MetricReverseDependenciesTransitive:
-			report[metric] = getMetricDependenciesTransitive(adjacencyList)
+			report[metric] = getMetricDependenciesTransitive(adjacencyListReverse)
 		}
 	}
 	reportJson, _ := json.MarshalIndent(report, "", "  ")

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -6,11 +6,11 @@ package cmd
 import (
 	"encoding/json"
 	"log"
+	"slices"
 	"strings"
 )
 
-type MetricDependenciesDirectType map[string]interface{}
-type MetricDependenciesTransitiveType map[string]interface{}
+type GenericMapStringToAny map[string]interface{}
 
 const (
 	MetricDependenciesDirect            = "deps-direct"
@@ -35,16 +35,24 @@ func isValidMetric(metric string) bool {
 	return false
 }
 
-func getMetricDependenciesDirect(adjacencyList AdjacencyList) MetricDependenciesDirectType {
-	depsCount := make(MetricDependenciesDirectType)
+/*
+Get direct dependencies given adjacency list (used both for dependencies and dependents)
+as it's just a mapping of node -> [nodes].
+*/
+func getMetricDependenciesDirect(adjacencyList AdjacencyList) GenericMapStringToAny {
+	depsCount := make(GenericMapStringToAny)
 	for key, deps := range adjacencyList {
 		depsCount[key] = len(deps)
 	}
 	return depsCount
 }
 
-func getMetricDependenciesTransitive(adjacencyList AdjacencyList) MetricDependenciesTransitiveType {
-	depsCount := make(MetricDependenciesTransitiveType)
+/*
+Get transitive dependencies given adjacency list (used both for dependencies and dependents)
+as it's just a mapping of node -> [nodes].
+*/
+func getMetricDependenciesTransitive(adjacencyList AdjacencyList) GenericMapStringToAny {
+	depsCount := make(GenericMapStringToAny)
 	visited := make(map[string]int)
 	for dep := range adjacencyList {
 		if count, found := visited[dep]; found {
@@ -64,10 +72,24 @@ var Metrics = metrics
 /*
 Produce data for given metrics.
 */
-func metrics(filePath string, metricsItems []string, readFile ReadFileFunc) []byte {
-	jsonData := readFile(filePath)
-	adjacencyList := loadJsonFile(jsonData)
+func metrics(filePathDg string, filePathDgReverse string, metricsItems []string, readFile ReadFileFunc) []byte {
+	var adjacencyList AdjacencyList
 	report := make(map[string]map[string]interface{})
+	// use dependencies adjacency list as is
+	if slices.Contains(metricsItems, MetricDependenciesDirect) || slices.Contains(metricsItems, MetricDependenciesTransitive) {
+		jsonData := readFile(filePathDg)
+		adjacencyList = loadJsonFile(jsonData)
+	}
+	// use the reversed dependencies list if provided otherwise reverse the dependencies list first
+	if slices.Contains(metricsItems, MetricReverseDependenciesDirect) || slices.Contains(metricsItems, MetricReverseDependenciesTransitive) {
+		if filePathDgReverse != "" {
+			jsonData := readFile(filePathDgReverse)
+			adjacencyList = loadJsonFile(jsonData)
+		} else {
+			jsonData := readFile(filePathDg)
+			adjacencyList = reverseAdjacencyLists(loadJsonFile(jsonData))
+		}
+	}
 
 	for _, metric := range metricsItems {
 		if !isValidMetric(metric) {
@@ -75,13 +97,19 @@ func metrics(filePath string, metricsItems []string, readFile ReadFileFunc) []by
 			return []byte("")
 		}
 		switch metric {
+
 		case MetricDependenciesDirect:
 			report[metric] = getMetricDependenciesDirect(adjacencyList)
 
 		case MetricDependenciesTransitive:
 			report[metric] = getMetricDependenciesTransitive(adjacencyList)
-		}
 
+		case MetricReverseDependenciesDirect:
+			report[metric] = getMetricDependenciesDirect(adjacencyList)
+
+		case MetricReverseDependenciesTransitive:
+			report[metric] = getMetricDependenciesTransitive(adjacencyList)
+		}
 	}
 	reportJson, _ := json.MarshalIndent(report, "", "  ")
 	return reportJson

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -77,11 +77,14 @@ func TestMetricsDependenciesDirect(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		metricsItems := []string{MetricDependenciesDirect}
-		result := metrics("mock.json", "", metricsItems, MockReadFile)
+		result, err := metrics("mock.json", "", metricsItems, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		var actualOutput map[string]map[string]int
 		json.Unmarshal(result, &actualOutput)
 		assert.Equal(t, testCase.expected, actualOutput["deps-direct"])
@@ -201,11 +204,14 @@ func TestMetricsDependenciesTransitive(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		metricsItems := []string{MetricDependenciesTransitive}
-		result := metrics("mock.json", "", metricsItems, MockReadFile)
+		result, err := metrics("mock.json", "", metricsItems, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		var actualOutput map[string]map[string]int
 		json.Unmarshal(result, &actualOutput)
 		assert.Equal(t, testCase.expected, actualOutput["deps-transitive"])
@@ -268,11 +274,14 @@ func TestMetricsReverseDependenciesDirect(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		metricsItems := []string{MetricReverseDependenciesDirect}
-		result := metrics("mock.json", "", metricsItems, MockReadFile)
+		result, err := metrics("mock.json", "", metricsItems, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		var actualOutput map[string]map[string]int
 		json.Unmarshal(result, &actualOutput)
 		assert.Equal(t, testCase.expected, actualOutput["rdeps-direct"])
@@ -360,11 +369,14 @@ func TestMetricsReverseDependenciesTransitive(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		MockReadFile := func(filePath string) []byte {
-			return testCase.input
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
 		}
 		metricsItems := []string{MetricReverseDependenciesTransitive}
-		result := metrics("mock.json", "", metricsItems, MockReadFile)
+		result, err := metrics("mock.json", "", metricsItems, MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
 		var actualOutput map[string]map[string]int
 		json.Unmarshal(result, &actualOutput)
 		assert.Equal(t, testCase.expected, actualOutput["rdeps-transitive"])
@@ -389,12 +401,15 @@ func TestMetricsCombined(t *testing.T) {
 	}
 	`)
 
-	MockReadFile := func(filePath string) []byte {
-		return input
+	MockReadFile := func(filePath string) ([]byte, error) {
+		return input, nil
 	}
 
 	metricsItems := []string{MetricDependenciesDirect, MetricDependenciesTransitive, MetricReverseDependenciesDirect, MetricReverseDependenciesTransitive}
-	result := metrics("mock.json", "", metricsItems, MockReadFile)
+	result, err := metrics("mock.json", "", metricsItems, MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
 	var actualOutput map[string]map[string]int
 	json.Unmarshal(result, &actualOutput)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,11 @@ var dependenciesCmd = &cobra.Command{
 		reflexive, _ := cmd.Flags().GetBool("reflexive")
 		depth, _ := cmd.Flags().GetInt("depth")
 
-		result := dependencies(filePath, targets, transitive, reflexive, depth, DefaultReadFile)
+		result, err := dependencies(filePath, targets, transitive, reflexive, depth, DefaultReadFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 		output := strings.Join(result, "\n")
 		cmd.OutOrStdout().Write([]byte(output))
 		cmd.OutOrStdout().Write([]byte("\n"))
@@ -56,8 +60,12 @@ var dependentsCmd = &cobra.Command{
 		reflexive, _ := cmd.Flags().GetBool("reflexive")
 		depth, _ := cmd.Flags().GetInt("depth")
 
-		result := dependents(filePathDg, filePathDgReverse,
+		result, err := dependents(filePathDg, filePathDgReverse,
 			targets, transitive, reflexive, depth, DefaultReadFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 		output := strings.Join(result, "\n")
 		cmd.OutOrStdout().Write([]byte(output))
 		cmd.OutOrStdout().Write([]byte("\n"))
@@ -72,7 +80,11 @@ var metricsCmd = &cobra.Command{
 		filePathDg, _ := cmd.Flags().GetString("dg")
 		filePathDgReverse, _ := cmd.Flags().GetString("rdg")
 		metricsItems, _ := cmd.Flags().GetStringSlice("metric")
-		result := metrics(filePathDg, filePathDgReverse, metricsItems, DefaultReadFile)
+		result, err := metrics(filePathDg, filePathDgReverse, metricsItems, DefaultReadFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 		cmd.OutOrStdout().Write(result)
 		cmd.OutOrStdout().Write([]byte("\n"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,9 +69,10 @@ var metricsCmd = &cobra.Command{
 	Short: "Get dependency graph related metrics",
 	Long:  `Get dependency graph related metrics`,
 	Run: func(cmd *cobra.Command, args []string) {
-		filePath, _ := cmd.Flags().GetString("dg")
+		filePathDg, _ := cmd.Flags().GetString("dg")
+		filePathDgReverse, _ := cmd.Flags().GetString("rdg")
 		metricsItems, _ := cmd.Flags().GetStringSlice("metric")
-		result := metrics(filePath, metricsItems, DefaultReadFile)
+		result := metrics(filePathDg, filePathDgReverse, metricsItems, DefaultReadFile)
 		cmd.OutOrStdout().Write(result)
 		cmd.OutOrStdout().Write([]byte("\n"))
 
@@ -106,6 +107,7 @@ func init() {
 	//make dg flag global for all commands as all of them will need dg data
 	RootCmd.PersistentFlags().StringVar(&dg, "dg", "", "JSON file with the dependency graph represented as an adjacency list")
 
+	metricsCmd.Flags().StringVar(&rdg, "rdg", "", "JSON file with the dependency graph represented as an adjacency list")
 	metricsCmd.Flags().StringSliceVar(&metricsFlags, "metric", []string{}, "Metrics to report")
 
 	dependenciesCmd.Flags().BoolP("transitive", "", false, "Get transitive dependencies")

--- a/tests/main_cli_test.go
+++ b/tests/main_cli_test.go
@@ -46,7 +46,9 @@ func TestCliMetrics(t *testing.T) {
 	cmd.RootCmd.SetOut(&buf)
 	cmd.RootCmd.SetErr(&buf)
 
-	cmd.RootCmd.SetArgs(append([]string{"metrics", "--metric=deps-direct", "--metric=deps-transitive", "--dg=examples/dg.json"}, "foo.py"))
+	cmd.RootCmd.SetArgs(append([]string{"metrics",
+		"--metric=deps-direct", "--metric=deps-transitive", "--metric=rdeps-direct", "--metric=rdeps-transitive",
+		"--dg=examples/dg.json"}, "foo.py"))
 	cmd.RootCmd.Execute()
 
 	expected := []byte(`
@@ -55,13 +57,49 @@ func TestCliMetrics(t *testing.T) {
 			"foo-dep1.py": 2,
 			"foo.py": 2,
 			"spam-dep2.py": 2,
-			"spam.py": 2
+			"spam.py": 2,
+			"foo-dep2.py": 0,
+			"spam-dep1.py": 0,
+			"foo-dep1-dep1.py": 0,
+			"foo-dep1-dep2.py": 0,
+			"spam-dep2-dep1.py": 0,
+			"spam-dep2-dep2.py": 0
 		},
 		"deps-transitive": {
 			"foo-dep1.py": 2,
 			"foo.py": 4,
 			"spam-dep2.py": 2,
-			"spam.py": 4
+			"spam.py": 4,
+			"foo-dep2.py": 0,
+			"spam-dep1.py": 0,
+			"foo-dep1-dep1.py": 0,
+			"foo-dep1-dep2.py": 0,
+			"spam-dep2-dep1.py": 0,
+			"spam-dep2-dep2.py": 0
+		},
+		"rdeps-direct": {
+			"foo-dep1-dep1.py": 1, 
+			"foo-dep1-dep2.py": 1, 
+			"foo-dep1.py": 1, 
+			"foo-dep2.py": 1, 
+			"foo.py": 0, 
+			"spam-dep1.py": 1, 
+			"spam-dep2-dep1.py": 1, 
+			"spam-dep2-dep2.py": 1, 
+			"spam-dep2.py": 1, 
+			"spam.py": 0
+		}, 
+		"rdeps-transitive": {
+			"foo-dep1-dep1.py": 2, 
+			"foo-dep1-dep2.py": 2, 
+			"foo-dep1.py": 1, 
+			"foo-dep2.py": 1, 
+			"foo.py": 0, 
+			"spam-dep1.py": 1, 
+			"spam-dep2-dep1.py": 2, 
+			"spam-dep2-dep2.py": 2, 
+			"spam-dep2.py": 1, 
+			"spam.py": 0
 		}
 		}
 	`)

--- a/tests/main_perf_test.go
+++ b/tests/main_perf_test.go
@@ -36,11 +36,14 @@ func TestDependenciesCommandPerfDeepGraph(t *testing.T) {
 
 	startTime := time.Now()
 	nodesCount := 10000
-	MockReadFile := func(filePath string) []byte {
+	MockReadFile := func(filePath string) ([]byte, error) {
 		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
-		return lists
+		return lists, nil
 	}
-	result := cmd.Dependencies("mock.json", []string{"1"}, true, false, 0, MockReadFile)
+	result, err := cmd.Dependencies("mock.json", []string{"1"}, true, false, 0, MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
 	expected := make([]string, nodesCount-1)
 	for i := range expected {
 		expected[i] = strconv.Itoa(i + 2)
@@ -61,14 +64,17 @@ func TestDependenciesCommandPerfDeepGraphDepthLimit(t *testing.T) {
 
 	startTime := time.Now()
 	nodesCount := 1000
-	MockReadFile := func(filePath string) []byte {
+	MockReadFile := func(filePath string) ([]byte, error) {
 		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
-		return lists
+		return lists, nil
 	}
 	transitive := true
 	reflexive := false
 	depth := 512
-	result := cmd.Dependencies("mock.json", []string{"1"}, transitive, reflexive, depth, MockReadFile)
+	result, err := cmd.Dependencies("mock.json", []string{"1"}, transitive, reflexive, depth, MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
 	expected := make([]string, 512)
 	for i := range expected {
 		expected[i] = strconv.Itoa(i + 2)
@@ -91,14 +97,17 @@ func TestDependentsCommandPerfDeepGraph(t *testing.T) {
 
 	// mocking function that reads a file from disk
 	nodesCount := 10000
-	MockReadFile := func(filePath string) []byte {
+	MockReadFile := func(filePath string) ([]byte, error) {
 		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
-		return lists
+		return lists, nil
 	}
 	transitive := true
 	reflexive := false
 	depth := 0
-	result := cmd.Dependents("mock-dg.json", "", []string{"10000"}, transitive, reflexive, depth, MockReadFile)
+	result, err := cmd.Dependents("mock-dg.json", "", []string{"10000"}, transitive, reflexive, depth, MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
 
 	expected := make([]string, nodesCount-1)
 	for i := range expected {
@@ -127,11 +136,14 @@ func TestMetricsCommandPerfDeepGraph(t *testing.T) {
 
 	startTime := time.Now()
 	nodesCount := 1000
-	MockReadFile := func(filePath string) []byte {
+	MockReadFile := func(filePath string) ([]byte, error) {
 		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
-		return lists
+		return lists, nil
 	}
-	result := cmd.Metrics("mock.json", "", []string{cmd.MetricDependenciesTransitive}, MockReadFile)
+	result, err := cmd.Metrics("mock.json", "", []string{cmd.MetricDependenciesTransitive}, MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
 	var actualOutput map[string]map[string]int
 	json.Unmarshal(result, &actualOutput)
 

--- a/tests/main_perf_test.go
+++ b/tests/main_perf_test.go
@@ -131,7 +131,7 @@ func TestMetricsCommandPerfDeepGraph(t *testing.T) {
 		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
 		return lists
 	}
-	result := cmd.Metrics("mock.json", []string{cmd.MetricDependenciesTransitive}, MockReadFile)
+	result := cmd.Metrics("mock.json", "", []string{cmd.MetricDependenciesTransitive}, MockReadFile)
 	var actualOutput map[string]map[string]int
 	json.Unmarshal(result, &actualOutput)
 


### PR DESCRIPTION
```
$ go run main.go metrics --dg="examples/dg-real-transitive.json" --metric=deps-transitive | jq                                                                     
{
  "deps-transitive": {
    "foo-dep1-dep1.py": 0,
    "foo-dep1-dep2.py": 0,
    "foo-dep1.py": 2,
    "foo-dep2.py": 0,
    "foo.py": 4,
    "spam-dep1.py": 0,
    "spam-dep2-dep1.py": 0,
    "spam-dep2-dep2.py": 0,
    "spam-dep2.py": 2,
    "spam.py": 4
  }
```