### PR TITLE
bazel,go: add code coverage

### DIFF
--- a/.buildkite/build-go.sh
+++ b/.buildkite/build-go.sh
@@ -31,7 +31,9 @@ staticcheck ./...
 
 echo --- 'Build project'
 go build
-go test ./...
+mkdir dist
+go test -test.v -coverprofile dist/coverage.out  ./...
+go tool cover -html dist/coverage.out -o dist/coverage.html
 
 echo --- 'Sanity check'
 go run main.go deps --dg='examples/dg-real.json' foo.py spam.py

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     commands:
       
       - "echo '--- Prepare environment'"
-      - sudo apt-get install wget tree
+      - sudo apt-get install wget tree libdatetime-perl libdatetime-format-dateparse-perl libcapture-tiny-perl -y
       - wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
       - chmod +x bazelisk-linux-amd64
       - sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
@@ -26,11 +26,16 @@ steps:
       
       - "echo '--- Test'"
       - bazel test --test_output=all --test_summary=detailed //... 
+
+      - "echo '--- Code coverage'"
+      - bazel coverage //... --combined_report=lcov && bazel run //:run_coverage_with_genhtml 
     
     artifact_paths: 
-      - bazel-testlogs/dg-query_test/test.xml
-
+      - bazel-testlogs/tests/dg-query_test/test.xml
 
   - label: ":go: Build"
     commands:
         - .buildkite/build-go.sh
+
+    artifact_paths: 
+      - dist/coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dg-query
 .vscode
 
 dist/
+coverage-html/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,7 +54,20 @@ sh_binary(
     srcs = ["scripts/codecov.sh"],
     data = [
         "@lcov//:genhtml", 
-        "@lcov//:bin"
-    ],
+        "@lcov//:bin",      
+        # find a way to refer to files with a `glob` or `filegroup`; none of these worked --
+        # the files are not included into the runfiles directory for some reason, so listing 
+        # them individually is required
+        "//cmd:dependencies.go",
+        "//cmd:dependencies_test.go",
+        "//cmd:dependents.go",
+        "//cmd:dependents_test.go",
+        "//cmd:dg.go",
+        "//cmd:metrics.go",
+        "//cmd:metrics_test.go",
+        "//cmd:paths.go",
+        "//cmd:paths_test.go",
+        "//cmd:root.go",
+    ], 
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,6 +52,6 @@ sh_binary(
     name = "run_coverage_with_genhtml",
     args = ["$(location @lcov//:bin/genhtml)"],
     srcs = ["scripts/codecov.sh"],
-    data = ["@lcov//:bin/genhtml"],
+    data = ["@lcov//:bin/genhtml", "@lcov//:lcov-files-lib"],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,7 +50,7 @@ go_binary(
 
 sh_binary(
     name = "run_coverage_with_genhtml",
-    args = "$(location @lcov//:bin/genhtml)",
+    args = ["$(location @lcov//:bin/genhtml)"],
     srcs = ["scripts/codecov.sh"],
     data = ["@lcov//:bin/genhtml"],
     visibility = ["//visibility:public"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,13 +50,13 @@ go_binary(
 
 sh_binary(
     name = "run_coverage_with_genhtml",
-    args = ["$(location @lcov//:genhtml)"],
     srcs = ["scripts/codecov.sh"],
+    args = ["$(location @lcov//:genhtml)"],
     data = [
-        "@lcov//:genhtml", 
-        "@lcov//:bin",      
+        "@lcov//:genhtml",
+        "@lcov//:bin",
         # find a way to refer to files with a `glob` or `filegroup`; none of these worked --
-        # the files are not included into the runfiles directory for some reason, so listing 
+        # the files are not included into the runfiles directory for some reason, so listing
         # them individually is required
         "//cmd:dependencies.go",
         "//cmd:dependencies_test.go",
@@ -68,6 +68,6 @@ sh_binary(
         "//cmd:paths.go",
         "//cmd:paths_test.go",
         "//cmd:root.go",
-    ], 
+    ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,8 +50,11 @@ go_binary(
 
 sh_binary(
     name = "run_coverage_with_genhtml",
-    args = ["$(location @lcov//:bin/genhtml)"],
+    args = ["$(location @lcov//:genhtml)"],
     srcs = ["scripts/codecov.sh"],
-    data = ["@lcov//:bin/genhtml", "@lcov//:lcov-files-lib"],
+    data = [
+        "@lcov//:genhtml", 
+        "@lcov//:bin"
+    ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,3 +47,10 @@ go_binary(
     embed = [":dg-query_lib"],
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "run_coverage_with_genhtml",
+    srcs = ["scripts/codecov.sh"],
+    data = ["@lcov//:bin/genhtml"],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,6 +50,7 @@ go_binary(
 
 sh_binary(
     name = "run_coverage_with_genhtml",
+    args = "$(location @lcov//:bin/genhtml)",
     srcs = ["scripts/codecov.sh"],
     data = ["@lcov//:bin/genhtml"],
     visibility = ["//visibility:public"],

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,6 @@ build-bazel:
 	bazel test //...
 
 codecov:
-	bazel coverage //... --combined_report=lcov && genhtml -o coverage-html bazel-out/_coverage/_coverage_report.dat
+	bazel coverage //... --combined_report=lcov
+	
 	google-chrome coverage-html/index.html

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,4 @@ build-bazel:
 
 codecov:
 	bazel coverage //... --combined_report=lcov
+	genhtml -o coverage-html bazel-out/_coverage/_coverage_report.dat

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,3 @@ build-bazel:
 
 codecov:
 	bazel coverage //... --combined_report=lcov
-	
-	google-chrome coverage-html/index.html

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ build-bazel:
 	bazel run //:dg-query
 	bazel build //... && bazel-bin/dg-query_/dg-query dependencies --dg="examples/dg-real.json" foo.py spam.py
 	bazel test //...
+
+codecov:
+	bazel coverage //... --combined_report=lcov && genhtml -o coverage-html bazel-out/_coverage/_coverage_report.dat
+	google-chrome coverage-html/index.html

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,4 +55,15 @@ http_archive(
     name = "lcov",
     urls = ["https://github.com/linux-test-project/lcov/releases/download/v2.1/lcov-2.1.tar.gz"],
     strip_prefix = "lcov-2.1",
+    sha256 = "4d01d9f551a3f0e868ce84742fb60aac4407e3fc1622635a07e29d70e38f1faf",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "lcov",
+    srcs = glob([
+        "bin/*",
+    ]),
+)
+    """
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,9 +60,15 @@ http_archive(
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "lcov",
+    name = "lcov-files-bin",
     srcs = glob([
         "bin/*",
+    ]),
+)
+
+filegroup(
+    name = "lcov-files-lib",
+    srcs = glob([
         "lib/*",
     ]),
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,16 +60,16 @@ http_archive(
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "lcov-files-bin",
+    name = "genhtml",
     srcs = glob([
-        "bin/*",
+        "bin/genhtml",
     ]),
 )
 
 filegroup(
-    name = "lcov-files-lib",
+    name = "bin",
     srcs = glob([
-        "lib/*",
+        "bin/*",
     ]),
 )
     """

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,7 @@ filegroup(
     name = "lcov",
     srcs = glob([
         "bin/*",
+        "lib/*",
     ]),
 )
     """

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,3 +50,9 @@ load("//:deps.bzl", "go_dependencies")
 
 # gazelle:repository_macro deps.bzl%go_dependencies
 go_dependencies()
+
+http_archive(
+    name = "lcov",
+    urls = ["https://github.com/linux-test-project/lcov/releases/download/v2.1/lcov-2.1.tar.gz"],
+    strip_prefix = "lcov-2.1",
+)

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# this is to be able to include Go sources into the sh_binary target generating HTML report
+exports_files(
+    glob(["*.go"]),
+    visibility = ["//visibility:public"],
+)
+
 go_library(
     name = "cmd",
     srcs = [
@@ -28,3 +34,4 @@ go_test(
     embed = [":cmd"],
     deps = ["@com_github_stretchr_testify//assert"],
 )
+

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -34,4 +34,3 @@ go_test(
     embed = [":cmd"],
     deps = ["@com_github_stretchr_testify//assert"],
 )
-

--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
+# This script is supposed to run after the `bazel coverage //... --combined_report=lcov` command
+# as it expects `bazel-out/_coverage/_coverage_report.dat` to exist on disk and it is not recommended
+# to run Bazel commands from within Bazel
+echo "Running codecov.sh Shell script to generate the HTML code coverage report"
 
 # Define the path to the genhtml binary inside the extracted lcov package
-GENHTML_BINARY=$1 #(bazel info output_base)/external/lcov/bin/genhtml
+GENHTML_BINARY=$1
 
 # Generate the HTML report using genhtml from the downloaded package
-$GENHTML_BINARY -o coverage-html $BUILD_WORKSPACE_DIRECTORY/bazel-out/_coverage/_coverage_report.dat
+RUNFILES_ROOT=$PWD
+$GENHTML_BINARY -o $BUILD_WORKSPACE_DIRECTORY/coverage-html $BUILD_WORKSPACE_DIRECTORY/bazel-out/_coverage/_coverage_report.dat

--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Define the path to the genhtml binary inside the extracted lcov package
+GENHTML_BINARY=$(bazel info output_base)/external/lcov/bin/genhtml
+
+# Run Bazel coverage
+bazel coverage //... --combined_report=lcov
+
+# Generate the HTML report using genhtml from the downloaded package
+$GENHTML_BINARY -o coverage-html bazel-out/_coverage/_coverage_report.dat

--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -3,8 +3,5 @@
 # Define the path to the genhtml binary inside the extracted lcov package
 GENHTML_BINARY=$1 #(bazel info output_base)/external/lcov/bin/genhtml
 
-# Run Bazel coverage
-bazel coverage //... --combined_report=lcov
-
 # Generate the HTML report using genhtml from the downloaded package
-$GENHTML_BINARY -o coverage-html bazel-out/_coverage/_coverage_report.dat
+$GENHTML_BINARY -o coverage-html $BUILD_WORKSPACE_DIRECTORY/bazel-out/_coverage/_coverage_report.dat

--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the path to the genhtml binary inside the extracted lcov package
-GENHTML_BINARY=$(bazel info output_base)/external/lcov/bin/genhtml
+GENHTML_BINARY=$1 #(bazel info output_base)/external/lcov/bin/genhtml
 
 # Run Bazel coverage
 bazel coverage //... --combined_report=lcov


### PR DESCRIPTION
```
$ bazel run //:run_coverage_with_genhtml
INFO: Analyzed target //:run_coverage_with_genhtml (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:run_coverage_with_genhtml up-to-date:
  bazel-bin/run_coverage_with_genhtml
INFO: Elapsed time: 0.090s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/run_coverage_with_genhtml external/lcov/bin/genhtml
Running codecov.sh Shell script to generate the HTML code coverage report
Reading tracefile dg-query/bazel-out/_coverage/_coverage_report.dat.
Found 6 entries.
Generating output.
Processing file cmd/dependencies.go
  lines=63 hit=59
Processing file cmd/metrics.go
  lines=91 hit=70
Processing file cmd/paths.go
  lines=34 hit=30
Processing file cmd/dependents.go
  lines=43 hit=31
Processing file cmd/root.go
  lines=93 hit=75
Processing file cmd/dg.go
  lines=13 hit=9
Overall coverage rate:
  source files: 6
  lines.......: 81.3% (274 of 337 lines)
  functions...: no data found
Message summary:
  no messages were reported
```