### PR TITLE
bazel: add buildifier support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,8 @@ steps:
       - "echo '--- Static checks'"
       - "echo 'Gazelle'"
       - bazel run //:gazelle -- -mode=diff
+      - "echo 'Buildifier'"
+      - bazel run //:buildifier-check
       - "echo 'gofmt'"
       # getting exit code 1 despite not needing to format anything, 
       # so running the gofmt in "check" mode and not inspecting the exit code.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,3 +71,39 @@ sh_binary(
     ],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "buildifier_bin",
+    srcs = ["@buildifier//file:buildifier"],
+)
+
+# to enable formatting of *.bzl files that are not picked up by Gazelle
+sh_binary(
+    name = "buildifier",
+    srcs = ["@buildifier//file:buildifier"],
+    args = [
+        "--lint=fix",
+        "-r",
+        ".",
+    ],
+    # one cannot use `glob` inside a Bazel package (as there's `tests/BUILD.bazel` file)
+    # so the file is stored in `defs/` instead
+    data = glob(["defs/defs.*"]),
+    visibility = ["//visibility:public"],
+)
+
+# TODO: put in a macro instead (why can't built-in targets be found in .bzl file?)
+sh_binary(
+    name = "buildifier-check",
+    srcs = ["@buildifier//file:buildifier"],
+    args = [
+        "--lint=warn",
+        "--mode=check",
+        "-r",
+        ".",
+    ],
+    # one cannot use `glob` inside a Bazel package (as there's `tests/BUILD.bazel` file)
+    # so the file is stored in `defs/` instead
+    data = glob(["defs/defs.*"]),
+    visibility = ["//visibility:public"],
+)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ run-go:
 
 build-bazel:
 	bazel run //:gazelle
+	bazel run //:buildifier
 	bazel run //:update-deps
 	bazel run //:dg-query
 	bazel build //... && bazel-bin/dg-query_/dg-query dependencies --dg="examples/dg-real.json" foo.py spam.py

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_archive(
     name = "com_github_sluongng_nogo_analyzer",
@@ -73,4 +74,13 @@ filegroup(
     ]),
 )
     """
+)
+
+# Buildifier setup
+http_file(
+    name = "buildifier",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"],
+    sha256 = "5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009",
+    downloaded_file_path = "buildifier",
+    executable = True,
 )

--- a/defs/defs.bzl
+++ b/defs/defs.bzl
@@ -1,3 +1,5 @@
+"""Macros and shared definition."""
+
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 def custom_go_test(name, srcs, tag, data = ["examples/dg.json"], deps = ["//cmd", "@com_github_stretchr_testify//assert"]):

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tests:defs.bzl", "custom_go_test")
+load("//:defs/defs.bzl", "custom_go_test")
 
 # gazelle:ignore
 custom_go_test(


### PR DESCRIPTION
```
$ bazel run //:run_buildifier             
INFO: Analyzed target //:buildifier (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:buildifier up-to-date:
  bazel-bin/buildifier
INFO: Elapsed time: 0.070s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/buildifier '--lint=fix' -r .
```