### PR TITLE
bazel: show timestamps in CI builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
 test --test_output=all
 test --test_summary=detailed
 test --test_arg=-test.v
+
+try-import %workspace%/.bazelrc.ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
       - bazel --version
       - bazel build //...
       - ls bazel-*
+      - echo "common --show_timestamps" > .bazelrc.ci
       
       - "echo '--- Static checks'"
       - "echo 'Gazelle'"


### PR DESCRIPTION
Add timestamps to any Bazel invocation, but only in CI.