### PR TITLE
go: add support for connected components count metric

### DIFF
--- a/tests/main_cli_test.go
+++ b/tests/main_cli_test.go
@@ -84,13 +84,16 @@ func TestCliMetrics(t *testing.T) {
 	cmd.RootCmd.SetOut(&buf)
 	cmd.RootCmd.SetErr(&buf)
 
-	cmd.RootCmd.SetArgs(append([]string{"metrics",
-		"--metric=deps-direct", "--metric=deps-transitive", "--metric=rdeps-direct", "--metric=rdeps-transitive",
-		"--dg=examples/dg.json"}, "foo.py"))
+	cmd.RootCmd.SetArgs([]string{"metrics",
+		"--metric=deps-direct", "--metric=deps-transitive", "--metric=rdeps-direct", "--metric=rdeps-transitive", "--metric=components-count",
+		"--dg=examples/dg.json"})
 	cmd.RootCmd.Execute()
 
 	expected := []byte(`
 		{
+		"components-count": {
+			"count": 2
+		},
 		"deps-direct": {
 			"foo-dep1.py": 2,
 			"foo.py": 2,


### PR DESCRIPTION
Adding support for finding connected components as part of metrics report, see https://en.wikipedia.org/wiki/Component_(graph_theory).