### PR TITLE
bazel: enable Docker sandbox for build actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,6 +42,24 @@ steps:
     artifact_paths: 
       - bazel-testlogs/tests/dg-query_test/test.xml
 
+  - label: ":bazel: Build in Docker"
+    commands:
+      - "echo '--- Prepare environment'"
+      - sudo apt-get install wget
+      - wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+      - chmod +x bazelisk-linux-amd64
+      - sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+      
+      - "echo '--- Build'"
+      - bazel --version
+      # `--load` ensures that the image built is loaded into the local Docker environment, 
+      # making it immediately available to run or reference by tag; otherwise, the image 
+      # will only exist in Docker's build cache.
+      - docker build -t go-build-env -f platforms/Dockerfile --load .
+      - docker image ls
+      - bazel build //... --spawn_strategy=docker --experimental_enable_docker_sandbox --platforms="//platforms:docker"
+      - bazel test //...  --spawn_strategy=docker --experimental_enable_docker_sandbox --platforms="//platforms:docker"
+
   - label: ":go: Build"
     commands:
         - .buildkite/build-go.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
+# to support spawning actions in a Docker container
+register_execution_platforms(
+    "//platforms:docker",
+)
+
 http_archive(
     name = "com_github_sluongng_nogo_analyzer",
     sha256 = "0dc6b5e86094d081e05bcd0c3e41fc275a2398c64e545376166139412181f150",

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,0 +1,11 @@
+# to support spawning actions in a Docker container
+platform(
+    name = "docker",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    exec_properties = {
+        "container-image": "docker://docker.io/go-build-env:latest",
+    },
+)

--- a/platforms/Dockerfile
+++ b/platforms/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:1.22


### PR DESCRIPTION
Add support to run build actions in a Docker container using a custom Docker image. See https://bazel.build/reference/be/platforms-and-toolchains#platform.