### PR TITLE
bazel: use stamping for Go binary to be released

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --noenable_bzlmod
+common --noenable_bzlmod
 
 test --test_output=all
 test --test_summary=detailed

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,10 @@ steps:
       - "echo '--- Code coverage'"
       - bazel coverage //... --combined_report=lcov && bazel run //:run_coverage_with_genhtml 
     
+      - "echo '--- Release binary with a stamp'"
+      - bazel build //:dg-query --stamp --workspace_status_command="build-support/workspace-status.sh"
+      - bazel-bin/dg-query_/dg-query | grep "Git revision"
+
     artifact_paths: 
       - bazel-testlogs/tests/dg-query_test/test.xml
 

--- a/build-support/workspace-status.sh
+++ b/build-support/workspace-status.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo STABLE_GIT_COMMIT $(git rev-parse HEAD)

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -18,6 +18,9 @@ go_library(
     ],
     importpath = "github.com/AlexTereshenkov/dg-query/cmd",
     visibility = ["//visibility:public"],
+    # This sets contents for variable `Version` in the `root.go` file;
+    # https://bazel.build/docs/user-manual#workspace-status
+    x_defs = {"Version": "{STABLE_GIT_COMMIT}"},
     deps = [
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,13 +12,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// This variable is going to be set by Bazel during stamping a Go binary;
+// https://github.com/bazel-contrib/rules_go/blob/master/docs/go/core/defines_and_stamping.md
+var Version = "(redacted)"
+
 // RootCmd represents the base command when called without any subcommands.
 // This needs to be exported to be available to `main.go`.
 var RootCmd = &cobra.Command{
 	Use:   "dg-query",
 	Short: "A command-line utility program to query dependency graph of a codebase.",
 	Long: `A command-line utility program to query dependency graph of a codebase
-which operates on the adjacency list data stored as a JSON file.`,
+which operates on the adjacency list data stored as a JSON file. 
+
+Git revision: ` + Version,
 }
 
 // getting dependencies of given targets in the dependency graph


### PR DESCRIPTION
Embed custom metadata obtained from Bazel build into the Go binary.

```
$ bazel build //:dg-query --stamp --workspace_status_command="build-support/workspace-status.sh"
$ bazel-bin/dg-query_/dg-query                       
A command-line utility program to query dependency graph of 
a codebase which operates on the adjacency list data stored as a JSON file. 

Git revision: 5bf78bee24df8909bd120d7f7f606346242d6a54

Usage:
  dg-query [command]
...
```

See https://github.com/bazel-contrib/rules_go/issues/1375.