### PR TITLE
go: add support for reporting cycles in the graph

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,6 +58,7 @@ sh_binary(
         # find a way to refer to files with a `glob` or `filegroup`; none of these worked --
         # the files are not included into the runfiles directory for some reason, so listing
         # them individually is required
+        "//cmd:cycles.go",
         "//cmd:dependencies.go",
         "//cmd:dependencies_test.go",
         "//cmd:dependents.go",

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -9,6 +9,7 @@ exports_files(
 go_library(
     name = "cmd",
     srcs = [
+        "cycles.go",
         "dependencies.go",
         "dependents.go",
         "dg.go",
@@ -29,6 +30,7 @@ go_library(
 go_test(
     name = "cmd_test",
     srcs = [
+        "cycles_test.go",
         "dependencies_test.go",
         "dependents_test.go",
         "metrics_test.go",

--- a/cmd/cycles.go
+++ b/cmd/cycles.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2024 Alexey Tereshenkov
+*/
+package cmd
+
+import "sort"
+
+func cycles(filePath string, readFile ReadFileFunc) ([][]string, error) {
+	jsonData, err := readFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	adjacencyList, err := loadJsonFile(jsonData)
+	if err != nil {
+		return nil, err
+	}
+
+	recursionStack := make(map[string]bool)
+	cycles := make(map[string][]string)
+
+	// Sort a cycle starting from a specific node
+	sortCycle := func(cycle []string) []string {
+		// Find the minimum element
+		minIdx := 0
+		for i := 1; i < len(cycle); i++ {
+			if cycle[i] < cycle[minIdx] {
+				minIdx = i
+			}
+		}
+
+		// Rotate the slice to place the minimum element at the start
+		result := make([]string, len(cycle))
+		for i := 0; i < len(cycle); i++ {
+			result[i] = cycle[(i+minIdx)%len(cycle)]
+		}
+		return result
+	}
+
+	// Create a unique key for given cycle
+	cycleKey := func(cycle []string) string {
+		sortedCycle := sortCycle(cycle)
+		result := ""
+		for _, node := range sortedCycle {
+			result += node
+		}
+		return result
+	}
+
+	var dfs func(node string, path []string)
+	dfs = func(node string, path []string) {
+		recursionStack[node] = true
+		path = append(path, node)
+
+		for _, neighbor := range adjacencyList[node] {
+			// Found a cycle
+			if recursionStack[neighbor] {
+				// Find the start of the cycle in the path
+				cycleStart := -1
+				for i, n := range path {
+					if n == neighbor {
+						cycleStart = i
+						break
+					}
+				}
+
+				if cycleStart != -1 {
+					cycle := path[cycleStart:]
+					sortedCycle := sortCycle(cycle)
+					// Use the sorted cycle string as key to avoid duplicates
+					key := cycleKey(cycle)
+					cycles[key] = sortedCycle
+				}
+			}
+
+			// Continue exploring if the neighbor isn't in the current path
+			// because there may be overlapping cycles (A->B->C->A & B->C->D->A)
+			if !recursionStack[neighbor] {
+				dfs(neighbor, path)
+			}
+		}
+
+		recursionStack[node] = false
+	}
+
+	for node := range adjacencyList {
+		if !recursionStack[node] {
+			dfs(node, []string{})
+		}
+	}
+
+	// Convert cycles map to slice and sort for consistent output
+	result := make([][]string, 0, len(cycles))
+	for _, cycle := range cycles {
+		result = append(result, cycle)
+	}
+
+	// Sort the cycles based on their first element for consistent output
+	sort.Slice(result, func(i, j int) bool {
+		return result[i][0] < result[j][0]
+	})
+
+	return result, nil
+}

--- a/cmd/cycles_test.go
+++ b/cmd/cycles_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright © 2024 Alexey Tereshenkov
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindCycles(t *testing.T) {
+
+	cases := []testCasePaths{
+		// no cycles
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"]
+			}`),
+			expected: [][]string{},
+		},
+		// one cycle with no other nodes
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["A"]
+			}`),
+			expected: [][]string{
+				{"A", "B"},
+			},
+		},
+		// one cycle with the node connected to itself
+		{
+			input: []byte(`
+            {
+                "A": ["A"]
+            }
+            `),
+			expected: [][]string{
+				{"A"},
+			},
+		},
+		// two cycles with the nodes connected to themselves
+		{
+			input: []byte(`
+            {
+                "A": ["A"],
+				"B": ["B"]
+            }
+            `),
+			expected: [][]string{
+				{"A"}, {"B"},
+			},
+		},
+		// one cycle among nodes outside of the cycle
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"], 
+				"C": ["A"],
+                "D": ["D1", "D2"]
+			}`),
+			expected: [][]string{
+				{"A", "B", "C"},
+			},
+		},
+		// two cycles
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["A"], 
+				"C": ["D"],
+                "D": ["C"]
+			}`),
+			expected: [][]string{
+				{"A", "B"}, {"C", "D"},
+			},
+		},
+		/* two cycles with a node in between
+		A -> B -> C  -> D -> E -> F -> G
+		^	 	  |   		 ^  	   |
+		|         |          |         |
+		-----<-----          -----<-----
+		*/
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"], 
+				"C": ["A", "D"],
+                "D": ["E"],
+				"E": ["F"],
+				"F": ["G"],
+				"G": ["E"]
+			}`),
+			expected: [][]string{
+				{"A", "B", "C"}, {"E", "F", "G"},
+			},
+		},
+		/* intervened cycles
+		A -> B -> C  -> D
+		^	 ^	  |     |
+		|    |    |     |
+		-----------------
+		*/
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"], 
+				"C": ["A", "D"],
+                "D": ["B"]
+			}`),
+			expected: [][]string{
+				{"A", "B", "C"}, {"B", "C", "D"},
+			},
+		},
+		/* inner cycle overlapping with an outer cycle (shared start node)
+		A -> B -> C  -> D -> E
+		^	 	  |     	 |
+		|         |          |
+		----<----------<-----
+		*/
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"], 
+				"C": ["A", "D"],
+                "D": ["E"],
+				"E": ["A"]
+			}`),
+			expected: [][]string{
+				{"A", "B", "C"}, {"A", "B", "C", "D", "E"},
+			},
+		},
+		/* inner cycle inside an outer cycle (distinct start nodes)
+			A -> B -> C  -> D -> E
+			^	 ^	 	    |    |
+		    |	 |          |    |
+			----<----------<------
+		*/
+		{
+			input: []byte(`{
+				"A": ["B"], 
+				"B": ["C"], 
+				"C": ["D"],
+                "D": ["B", "E"],
+				"E": ["A"]
+			}`),
+			expected: [][]string{
+				{"B", "C", "D"}, {"A", "B", "C", "D", "E"},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
+		}
+		result, err := cycles("mock-dg.json", MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
+		// the order of cycles may change depending on the implementation of the DFS,
+		// but the order the cycles are returned in shouldn't really matter
+		assert.ElementsMatch(t, testCase.expected, result)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,6 +119,24 @@ var pathsCmd = &cobra.Command{
 	},
 }
 
+var cyclesCmd = &cobra.Command{
+	Use:   "cycles",
+	Short: "Find cycles in the dependency graph",
+	Long:  `Find cycles in the dependency graph`,
+	Run: func(cmd *cobra.Command, targets []string) {
+		filePath, _ := cmd.Flags().GetString("dg")
+		result, err := cycles(filePath, DefaultReadFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		resultJson, _ := json.MarshalIndent(result, "", "  ")
+		cmd.OutOrStdout().Write(resultJson)
+		cmd.OutOrStdout().Write([]byte("\n"))
+
+	},
+}
+
 // JSON file with the dependency graph represented as an adjacency list
 var dg string
 var rdg string
@@ -146,6 +164,7 @@ func init() {
 	// will be global for your application.
 	RootCmd.AddCommand(metricsCmd)
 	RootCmd.AddCommand(pathsCmd)
+	RootCmd.AddCommand(cyclesCmd)
 	RootCmd.AddCommand(dependenciesCmd)
 	RootCmd.AddCommand(dependentsCmd)
 

--- a/tests/main_cli_test.go
+++ b/tests/main_cli_test.go
@@ -59,6 +59,25 @@ func TestCliPaths(t *testing.T) {
 	buf.Reset()
 }
 
+func TestCliCycles(t *testing.T) {
+
+	var buf bytes.Buffer
+	cmd.RootCmd.SetOut(&buf)
+	cmd.RootCmd.SetErr(&buf)
+
+	cmd.RootCmd.SetArgs([]string{"cycles", "--dg=examples/dg.json"})
+	cmd.RootCmd.Execute()
+
+	expected := []byte(`[]`)
+
+	var actualOutput [][]string
+	var expectedOutput [][]string
+	json.Unmarshal(buf.Bytes(), &actualOutput)
+	json.Unmarshal(expected, &expectedOutput)
+	assert.Equal(t, expectedOutput, actualOutput)
+	buf.Reset()
+}
+
 func TestCliMetrics(t *testing.T) {
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Add support for reporting cycles in the graph.

See https://en.wikipedia.org/wiki/Cycle_(graph_theory).