### PR TITLE
bazel: use remote cache of BuildBuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,16 @@
 common --noenable_bzlmod
 
+# this is to pass build metadata to BuildBuddy and other parties
+build --workspace_status_command="build-support/workspace-status.sh
+
 test --test_output=all
 test --test_summary=detailed
 test --test_arg=-test.v
+
+# BuildBuddy remote cache configuration (read&write)
+build --bes_results_url=https://app.buildbuddy.io/invocation/
+build --bes_backend=grpcs://remote.buildbuddy.io
+build --remote_cache=grpcs://remote.buildbuddy.io
+build --remote_timeout=3600
 
 try-import %workspace%/.bazelrc.ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,7 @@ steps:
       
       - "echo '--- Build'"
       - bazel --version
-      - bazel build //...
-      - ls bazel-*
-      - echo "common --show_timestamps" > .bazelrc.ci
+      - build-support/create-bazelrc-ci.sh
       
       - "echo '--- Static checks'"
       - "echo 'Gazelle'"
@@ -40,7 +38,7 @@ steps:
       - bazel coverage //... --combined_report=lcov && bazel run //:run_coverage_with_genhtml 
     
       - "echo '--- Release binary with a stamp'"
-      - bazel build //:dg-query --stamp --workspace_status_command="build-support/workspace-status.sh"
+      - bazel build //:dg-query --stamp
       - bazel-bin/dg-query_/dg-query | grep "Git revision"
 
     artifact_paths: 
@@ -56,6 +54,7 @@ steps:
       
       - "echo '--- Build'"
       - bazel --version
+      - build-support/create-bazelrc-ci.sh
       # `--load` ensures that the image built is loaded into the local Docker environment, 
       # making it immediately available to run or reference by tag; otherwise, the image 
       # will only exist in Docker's build cache.

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,14 @@ run-go:
 	go run main.go dependencies --dg="examples/dg-real.json" foo.py spam.py
 
 build-bazel:
+	build-support/create-bazelrc-ci.sh
 	bazel run //:gazelle
 	bazel run //:buildifier
 	bazel run //:update-deps
 	bazel run //:dg-query
 	bazel build //... && bazel-bin/dg-query_/dg-query dependencies --dg="examples/dg-real.json" foo.py spam.py
 	bazel test //...
+	rm .bazelrc.ci
 
 codecov:
 	bazel coverage //... --combined_report=lcov

--- a/build-support/create-bazelrc-ci.sh
+++ b/build-support/create-bazelrc-ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "common --show_timestamps" > .bazelrc.ci
+echo "build --build_metadata=ROLE=CI" >> .bazelrc.ci
+
+# this secret is declared in Buildkite secrets
+if command -v buildkite-agent &> /dev/null
+then
+    # runs in Buildkite
+    BUILD_BUDDY_API_KEY=$(buildkite-agent secret get BUILD_BUDDY_API_KEY)
+else
+    # runs locally and the api key should be available via the environment variable
+    BUILD_BUDDY_API_KEY=${BUILD_BUDDY_API_KEY}
+fi
+echo "build --remote_header=x-buildbuddy-api-key=$BUILD_BUDDY_API_KEY" >> .bazelrc.ci

--- a/build-support/workspace-status.sh
+++ b/build-support/workspace-status.sh
@@ -1,2 +1,36 @@
 #!/usr/bin/env bash
-echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
+# adopted from https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh
+
+# This script will be run bazel when building process starts to
+# generate key-value information that represents the status of the
+# workspace. The output should be like
+#
+# KEY1 VALUE1
+# KEY2 VALUE2
+#
+# If the script exits with non-zero code, it's considered as a failure
+# and the output will be discarded.
+
+# these are sent to BuildBuddy as build metadata
+# it should be `GIT_BRANCH` as per
+# https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh
+# when called from the workspace status Shell script, and it should be
+# BRANCH_NAME as per https://www.buildbuddy.io/docs/guide-metadata#build-metadata-1
+# when called from the command line.
+if [[ -n "$BUILDKITE_BRANCH" ]]; then
+    git_branch="${BUILDKITE_BRANCH}"
+else
+    git_branch="$(git rev-parse --abbrev-ref HEAD)"
+fi
+echo "GIT_BRANCH $git_branch"
+
+echo "COMMIT_SHA $(git rev-parse HEAD)"
+
+echo "REPO_URL https://github.com/AlexTereshenkov/dg-query.git"
+
+# The "STABLE_" suffix causes these to be part of the "stable" workspace
+# status, which may trigger rebuilds of certain targets if these values change
+# and you're building with the "--stamp" flag.
+
+# this is embedded into the Go release binary
+echo "STABLE_GIT_COMMIT $(git rev-parse HEAD)"


### PR DESCRIPTION
Use BuildBuddy remote cache (free tier). See https://www.buildbuddy.io/docs/cloud.

