### PR TITLE
bazel: use remote execution of BuildBuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,4 +13,9 @@ build --bes_backend=grpcs://remote.buildbuddy.io
 build --remote_cache=grpcs://remote.buildbuddy.io
 build --remote_timeout=3600
 
+# BuildBuddy remote cache/execution recommended flags 
+build --experimental_remote_cache_compression
+build --experimental_remote_cache_compression_threshold=100
+build --nolegacy_important_outputs
+
 try-import %workspace%/.bazelrc.ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,21 @@ steps:
       - bazel build //... --spawn_strategy=docker --experimental_enable_docker_sandbox --platforms="//platforms:docker"
       - bazel test //...  --spawn_strategy=docker --experimental_enable_docker_sandbox --platforms="//platforms:docker"
 
+  - label: ":bazel: Build remote (BuildBuddy)"
+    commands:
+      - "echo '--- Prepare environment'"
+      - sudo apt-get install wget
+      - wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+      - chmod +x bazelisk-linux-amd64
+      - sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+      
+      - "echo '--- Build'"
+      - bazel --version
+      - build-support/create-bazelrc-ci.sh
+      - echo "build --remote_executor=grpcs://remote.buildbuddy.io" >> .bazelrc.ci
+      - bazel build //... 
+      - bazel test //...
+
   - label: ":go: Build"
     commands:
         - .buildkite/build-go.sh

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -2,7 +2,7 @@
 # constraint_value()s and platform()s that are universally useful across languages.
 # See https://bazel.build/extending/platforms to learn more about platforms.
 
-# to support spawning actions in a Docker container
+# To support spawning actions in a Docker container
 platform(
     name = "docker",
     constraint_values = [
@@ -10,8 +10,15 @@ platform(
         "@platforms//os:linux",
     ],
     exec_properties = {
-        "container-image": "docker://docker.io/go-build-env:latest",
+        # This can be changed to "docker://docker.io/go-build-env:latest"
+        # if a custom Docker image (built locally from the Dockerfile)
+        # needs to be used; this would require making sure that this
+        # Docker image is available on remote executors or only building
+        # targets while excluding any dependent targets or toolchains that
+        # might require that particular Docker image.
+        "container-image": "docker://docker.io/golang:1.22",
     },
+    tags = ["platform-docker"],
 )
 
 # Running `bazel test //... --platforms="//platforms:windows"` would result in running
@@ -22,4 +29,5 @@ platform(
         "@platforms//cpu:x86_64",
         "@platforms//os:windows",
     ],
+    tags = ["platform-windows"],
 )

--- a/platforms/Dockerfile
+++ b/platforms/Dockerfile
@@ -1,1 +1,8 @@
+# Currently not used
+
+# Use this to create a custom image where build actions can be run
+# when building with 
+# --spawn_strategy=docker
+# --experimental_enable_docker_sandbox
+# --platforms="//platforms:docker"
 FROM golang:1.22


### PR DESCRIPTION
Enable remote execution via BuildBuddy (free tier). See https://www.buildbuddy.io/docs/cloud.