### PR TITLE
bazel: load constants from a separate .bzl file

### DIFF
--- a/.buildkite/build-bazel.sh
+++ b/.buildkite/build-bazel.sh
@@ -9,6 +9,7 @@ echo 'Gazelle'
 bazel run //:gazelle -- -mode=diff
 echo 'Buildifier'
 bazel run //:buildifier-check
+bazel run //:buildifier
 echo 'gofmt'
 output=$(bazel run @rules_go//go -- fmt .) && [[ -n "$output" ]] && echo "$output" && exit 1 || echo "No formatting required"
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,12 +6,14 @@ gazelle(name = "gazelle")
 
 buildifier(
     name = "buildifier",
+    exclude_patterns = ["./defs/constants.bzl"],
     lint_mode = "fix",
     mode = "fix",
 )
 
 buildifier(
     name = "buildifier-check",
+    exclude_patterns = ["./defs/constants.bzl"],
     lint_mode = "warn",
     mode = "diff",
 )

--- a/defs/constants.bzl
+++ b/defs/constants.bzl
@@ -1,0 +1,3 @@
+"""Constants to be used by rules."""
+# This file is not formatted with Buildifier on purpose to allow custom formatting
+EXAMPLES_DG_JSON="examples/dg.json"

--- a/defs/defs.bzl
+++ b/defs/defs.bzl
@@ -1,12 +1,13 @@
 """Macros and shared definition."""
 
 load("@rules_go//go:def.bzl", "go_test")
+load("//:defs/constants.bzl", "EXAMPLES_DG_JSON")
 
 def custom_go_test(
         name,
         srcs,
         tag,
-        data = ["examples/dg.json"],
+        data = [EXAMPLES_DG_JSON],
         deps = ["//cmd", "@com_github_stretchr_testify//assert", "@com_github_spf13_cast//:cast"]):
     go_test(
         name = name,


### PR DESCRIPTION
Add support for loading constants from a separate `.bzl` file and exclude that file from the buildifier formatting operation.