### PR TITLE
go: add support for listing connected components

### DIFF
--- a/.buildkite/build-bazel-docker.sh
+++ b/.buildkite/build-bazel-docker.sh
@@ -1,4 +1,5 @@
-#! /bin/bash -xue
+#! /bin/bash
+set -xueo pipefail
 
 echo '--- Build'
 bazel --version

--- a/.buildkite/build-bazel-remote.sh
+++ b/.buildkite/build-bazel-remote.sh
@@ -1,4 +1,5 @@
-#! /bin/bash -xue
+#! /bin/bash
+set -xueo pipefail
 
 echo '--- Build'
 bazel --version

--- a/.buildkite/build-bazel.sh
+++ b/.buildkite/build-bazel.sh
@@ -1,4 +1,5 @@
-#! /bin/bash -xue
+#! /bin/bash 
+set -xueo pipefail
 
 echo '--- Build'
 bazel --version

--- a/.buildkite/build-go.sh
+++ b/.buildkite/build-go.sh
@@ -1,4 +1,6 @@
-#! /bin/bash -xue
+#! /bin/bash
+set -xueo pipefail
+
 echo '--- Prepare environment'
 sudo apt-get install wget jq -y
 wget https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ Find [cycles](https://en.wikipedia.org/wiki/Cycle_(graph_theory)) in the depende
 This is useful when you use a build system that doesn't tolerate cycles and you want to
 get a list of all of them at once.
 
+### `components`
+Find [components](https://en.wikipedia.org/wiki/Component_(graph_theory)) in the dependency graph.
+This is useful when you want to find out how well your repository is separated in terms of independent
+modules or projects.
+
 ### `subgraph`
 Extract [subgraph](https://en.wikipedia.org/wiki/Glossary_of_graph_theory#subgraph) out of the dependency graph.
 This is useful when you want to visualize a subset of the dependency graph or study it closer.
 
 ### `metrics`
-
 Get dependency graph related metrics. A dependency graph (`--dg`) may be used,
 or a reverse dependency graph (`--rdg`) may be used, if you have one.
 

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -15,6 +15,7 @@ filegroup(
 go_library(
     name = "cmd",
     srcs = [
+        "components.go",
         "cycles.go",
         "dependencies.go",
         "dependents.go",
@@ -37,6 +38,7 @@ go_library(
 go_test(
     name = "cmd_test",
     srcs = [
+        "components_test.go",
         "cycles_test.go",
         "dependencies_test.go",
         "dependents_test.go",

--- a/cmd/components.go
+++ b/cmd/components.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2024 Alexey Tereshenkov
+*/
+package cmd
+
+import "sort"
+
+// to be used in non-unit tests
+var ListConnectedComponents = listConnectedComponents
+
+// listConnectedComponents lists connected components in a graph given a filepath
+func listConnectedComponents(filePath string, readFile ReadFileFunc) ([][]string, error) {
+	jsonData, err := readFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	adjacencyList, err := loadJsonFile(jsonData)
+	if err != nil {
+		return nil, err
+	}
+	return getConnectedComponents(adjacencyList), nil
+}
+
+// getConnectedComponents finds connected components in a graph
+func getConnectedComponents(adjacencyList AdjacencyList) [][]string {
+
+	// Convert directed graph to undirected by adding reverse edges;
+	// this is necessary so that when node A is connected to B, we could
+	// automatically say that B is connected to A.
+	undirectedGraph := make(AdjacencyList)
+
+	// Initialize all nodes from the original adjacency list
+	for node := range adjacencyList {
+		if _, exists := undirectedGraph[node]; !exists {
+			undirectedGraph[node] = make([]string, 0)
+		}
+	}
+
+	// Add connectivity edges in both directions
+	for node, neighbors := range adjacencyList {
+		for _, neighbor := range neighbors {
+			// Add forward edge
+			undirectedGraph[node] = append(undirectedGraph[node], neighbor)
+			// Initialize neighbor if it does not exist
+			if _, exists := undirectedGraph[neighbor]; !exists {
+				undirectedGraph[neighbor] = make([]string, 0)
+			}
+			// Add reverse edge
+			undirectedGraph[neighbor] = append(undirectedGraph[neighbor], node)
+		}
+	}
+
+	visitedNodes := make(map[string]bool)
+	// initialize to an empty slice (returned for empty adjacency list)
+	connectedComponents := make([][]string, 0)
+
+	var dfs func(node string, component *[]string)
+	dfs = func(node string, component *[]string) {
+		visitedNodes[node] = true
+		*component = append(*component, node)
+
+		for _, neighbor := range undirectedGraph[node] {
+			if !visitedNodes[neighbor] {
+				dfs(neighbor, component)
+			}
+		}
+	}
+
+	// Sort all nodes for consistent traversal order; this is necessary
+	// to ensure the components are reported back in the same order
+	nodes := make([]string, 0)
+	for node := range undirectedGraph {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	// Find components starting from each unvisited node in the
+	// undirected graph that was built earlier
+	for _, node := range nodes {
+		if !visitedNodes[node] {
+			component := make([]string, 0)
+			dfs(node, &component)
+			sort.Strings(component)
+			connectedComponents = append(connectedComponents, component)
+		}
+	}
+
+	// Sort components by their first element for readability
+	sort.Slice(connectedComponents, func(i, j int) bool {
+		return connectedComponents[i][0] < connectedComponents[j][0]
+	})
+
+	return connectedComponents
+}

--- a/cmd/components_test.go
+++ b/cmd/components_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright © 2024 Alexey Tereshenkov
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestCaseComponents struct {
+	input    []byte
+	expected [][]string
+}
+
+func TestGetConnectedComponents(t *testing.T) {
+	cases := []TestCaseComponents{
+		// base case
+		{
+			input: []byte(`
+			{
+				"foo": ["bar"],
+				"bar": ["spam"],
+				"baz": ["eggs"],
+				"eggs": ["cheese"]
+			}
+			`),
+			expected: [][]string{
+				{"bar", "foo", "spam"},
+				{"baz", "cheese", "eggs"},
+			},
+		},
+		// empty graph
+		{
+			input:    []byte(`{}`),
+			expected: [][]string{},
+		},
+		// one component
+		{
+			input: []byte(`
+			{
+				"foo": ["bar"],
+				"bar": ["spam"],
+				"spam": ["eggs"],
+				"eggs": ["cheese"],
+				"cheese": []
+			}
+			`),
+			expected: [][]string{{"bar", "cheese", "eggs", "foo", "spam"}},
+		},
+		// one component
+		{
+			input: []byte(`
+			{
+				"foo": []
+			}
+			`),
+			expected: [][]string{{"foo"}},
+		},
+		// three components with each component being a single node
+		{
+			input: []byte(`
+			{
+				"foo": [],
+				"bar": [],
+				"baz": []
+			}
+			`),
+			expected: [][]string{{"bar"}, {"baz"}, {"foo"}},
+		},
+		// two components
+		{
+			input: []byte(`
+			{
+				"foo": ["bar", "baz"],
+				"bar": ["eggs", "spam"],
+				"baz": ["ham", "beans"],
+
+				"foo1": ["bar1", "baz1"],
+				"bar1": ["eggs1", "spam1"],
+				"baz1": ["ham1", "beans1"]
+			}
+			`),
+			expected: [][]string{
+				{"bar", "baz", "beans", "eggs", "foo", "ham", "spam"},
+				{"bar1", "baz1", "beans1", "eggs1", "foo1", "ham1", "spam1"},
+			},
+		},
+		// three components with components of varying size
+		{
+			input: []byte(`
+			{
+				"foo": ["bar", "baz"],
+				"bar": ["baz"],
+				"ham": ["beans"],
+				"cheese": []
+			}
+			`),
+			expected: [][]string{
+				{"bar", "baz", "foo"},
+				{"beans", "ham"},
+				{"cheese"},
+			},
+		},
+		// complex interconnected graph with four components (with one component being a cycle)
+		{
+			input: []byte(`
+			{
+				"a": ["b", "c"],
+				"b": ["d"],
+				"e": ["f"],
+				"g": ["h"],
+				"h": ["i"],
+				"i": ["g"],
+				"j": []
+			}
+			`),
+			expected: [][]string{
+				{"a", "b", "c", "d"},
+				{"e", "f"},
+				{"g", "h", "i"},
+				{"j"},
+			},
+		},
+		// one cycle is one component
+		{
+			input: []byte(`
+			{
+				"foo": ["bar"],
+				"bar": ["baz"],
+				"baz": ["foo"]
+			}
+			`),
+			expected: [][]string{{"bar", "baz", "foo"}},
+		},
+		// one cycle with the node connected to itself is still one component
+		{
+			input: []byte(`
+			{
+				"foo": ["foo"]
+			}
+			`),
+			expected: [][]string{{"foo"}},
+		},
+		// two cycles is two components
+		{
+			input: []byte(`
+			{
+				"foo": ["bar"],
+				"bar": ["foo"],
+				"baz": ["spam"],
+				"spam": ["baz"]
+			}
+			`),
+			expected: [][]string{
+				{"bar", "foo"},
+				{"baz", "spam"},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		MockReadFile := func(filePath string) ([]byte, error) {
+			return testCase.input, nil
+		}
+		components, err := listConnectedComponents("mock.json", MockReadFile)
+		if err != nil {
+			t.Fail()
+		}
+		assert.Equal(t, testCase.expected, components)
+	}
+}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"log"
 	"slices"
-	"sort"
 	"strings"
 )
 
@@ -18,8 +17,7 @@ const (
 	MetricDependenciesTransitive        = "deps-transitive"
 	MetricReverseDependenciesDirect     = "rdeps-direct"
 	MetricReverseDependenciesTransitive = "rdeps-transitive"
-	// https://en.wikipedia.org/wiki/Component_(graph_theory)
-	MetricConnectedComponentsCount = "components-count"
+	MetricConnectedComponentsCount      = "components-count"
 )
 
 var allowedMetrics = []string{
@@ -86,76 +84,6 @@ func getMetricDependenciesTransitive(adjacencyList AdjacencyList) GenericMapStri
 		}
 	}
 	return depsCount
-}
-
-// getConnectedComponents finds connected components in a graph
-func getConnectedComponents(adjacencyList AdjacencyList) [][]string {
-	// Convert directed graph to undirected by adding reverse edges;
-	// this is necessary so that when node A is connected to B, we could
-	// automatically say that B is connected to A.
-	undirectedGraph := make(AdjacencyList)
-
-	// Initialize all nodes from the original adjacency list
-	for node := range adjacencyList {
-		if _, exists := undirectedGraph[node]; !exists {
-			undirectedGraph[node] = make([]string, 0)
-		}
-	}
-
-	// Add connectivity edges in both directions
-	for node, neighbors := range adjacencyList {
-		for _, neighbor := range neighbors {
-			// Add forward edge
-			undirectedGraph[node] = append(undirectedGraph[node], neighbor)
-			// Initialize neighbor if it does not exist
-			if _, exists := undirectedGraph[neighbor]; !exists {
-				undirectedGraph[neighbor] = make([]string, 0)
-			}
-			// Add reverse edge
-			undirectedGraph[neighbor] = append(undirectedGraph[neighbor], node)
-		}
-	}
-
-	visitedNodes := make(map[string]bool)
-	var connectedComponents [][]string
-
-	var dfs func(node string, component *[]string)
-	dfs = func(node string, component *[]string) {
-		visitedNodes[node] = true
-		*component = append(*component, node)
-
-		for _, neighbor := range undirectedGraph[node] {
-			if !visitedNodes[neighbor] {
-				dfs(neighbor, component)
-			}
-		}
-	}
-
-	// Sort all nodes for consistent traversal order; this is necessary
-	// to ensure the components are reported back in the same order
-	nodes := make([]string, 0)
-	for node := range undirectedGraph {
-		nodes = append(nodes, node)
-	}
-	sort.Strings(nodes)
-
-	// Find components starting from each unvisited node in the
-	// undirected graph that was built earlier
-	for _, node := range nodes {
-		if !visitedNodes[node] {
-			component := make([]string, 0)
-			dfs(node, &component)
-			sort.Strings(component)
-			connectedComponents = append(connectedComponents, component)
-		}
-	}
-
-	// Sort components by their first element for readability
-	sort.Slice(connectedComponents, func(i, j int) bool {
-		return connectedComponents[i][0] < connectedComponents[j][0]
-	})
-
-	return connectedComponents
 }
 
 // getConnectedComponentsCount gets count of connected components in a graph

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,6 +156,24 @@ var subgraphCmd = &cobra.Command{
 	},
 }
 
+var componentsCmd = &cobra.Command{
+	Use:   "components",
+	Short: "Get a list of connected components in the dependency graph",
+	Long:  `Get a list of connected components in the dependency graph`,
+	Run: func(cmd *cobra.Command, targets []string) {
+		filePath, _ := cmd.Flags().GetString("dg")
+		result, err := listConnectedComponents(filePath, DefaultReadFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		resultJson, _ := json.MarshalIndent(result, "", "  ")
+		cmd.OutOrStdout().Write(resultJson)
+		cmd.OutOrStdout().Write([]byte("\n"))
+
+	},
+}
+
 // JSON file with the dependency graph represented as an adjacency list
 var dg string
 var rdg string
@@ -190,6 +208,7 @@ func init() {
 	RootCmd.AddCommand(subgraphCmd)
 	RootCmd.AddCommand(dependenciesCmd)
 	RootCmd.AddCommand(dependentsCmd)
+	RootCmd.AddCommand(componentsCmd)
 
 	//make dg flag global for all commands as all of them will need dg data
 	RootCmd.PersistentFlags().StringVar(&dg, "dg", "", "JSON file with the dependency graph represented as an adjacency list")

--- a/tests/main_cli_test.go
+++ b/tests/main_cli_test.go
@@ -95,6 +95,29 @@ func TestCliSubgraph(t *testing.T) {
 	buf.Reset()
 }
 
+func TestCliComponents(t *testing.T) {
+	var buf bytes.Buffer
+	cmd.RootCmd.SetOut(&buf)
+	cmd.RootCmd.SetErr(&buf)
+
+	cmd.RootCmd.SetArgs([]string{"components", "--dg=examples/dg.json"})
+	cmd.RootCmd.Execute()
+
+	expected := []byte(`
+	[
+		["foo-dep1-dep1.py","foo-dep1-dep2.py","foo-dep1.py","foo-dep2.py","foo.py"],
+		["spam-dep1.py","spam-dep2-dep1.py","spam-dep2-dep2.py","spam-dep2.py","spam.py"]
+	]
+	`)
+
+	var actualOutput [][]string
+	var expectedOutput [][]string
+	json.Unmarshal(buf.Bytes(), &actualOutput)
+	json.Unmarshal(expected, &expectedOutput)
+	assert.Equal(t, expectedOutput, actualOutput)
+	buf.Reset()
+}
+
 func TestCliMetrics(t *testing.T) {
 
 	var buf bytes.Buffer

--- a/tests/main_perf_test.go
+++ b/tests/main_perf_test.go
@@ -205,3 +205,26 @@ func TestSubgraphCommandPerfDeepGraph(t *testing.T) {
 		t.Fatalf("Getting subgraph in a large graph took too long: %s.", elapsedTime)
 	}
 }
+
+/*
+Testing performance of getting connected components for a root node in a
+deeply nested graph, i.e. {1: [2], 2: [3], 3: [4]..., N: [N+1]}
+*/
+func TestConnectedComponentsCommandPerfDeepGraph(t *testing.T) {
+
+	startTime := time.Now()
+	nodesCount := 10000
+	MockReadFile := func(filePath string) ([]byte, error) {
+		lists, _ := json.Marshal(createAdjacencyLists(nodesCount))
+		return lists, nil
+	}
+	result, err := cmd.ListConnectedComponents("mock.json", MockReadFile)
+	if err != nil {
+		t.Fail()
+	}
+	assert.Equal(t, 10000, len(result[0]), "Failing assertion")
+	elapsedTime := time.Since(startTime)
+	if elapsedTime.Seconds() > 1 {
+		t.Fatalf("Getting subgraph in a large graph took too long: %s.", elapsedTime)
+	}
+}


### PR DESCRIPTION
Add support for listing connected components in the dependency graph. This complements the components count metric that was added earlier.