### PR TITLE
bazel: add support for Windows builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,12 @@ test --test_output=all
 test --test_summary=detailed
 test --test_arg=-test.v
 
+# Windows builds only; by default, a Linux compatible platform is used
+common:windows --platforms=//platforms:windows
+
+# For Docker builds only
+common:docker --platforms=//platforms:docker
+
 # BuildBuddy remote cache configuration (read&write)
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://remote.buildbuddy.io

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,5 +40,14 @@ use_repo(
     "com_github_stretchr_testify",
 )
 
+# one cannot register both Windows and Linux platforms here because it means Bazel will
+# attempt to download/setup Go toolchains for both platforms (e.g. running Bazel on
+# Windows would attempt to download Linux Go SDK which would lead to build failure);
+# the registration of platforms happens in the `.bazelrc` file instead, so for Windows
+# builds, add `--config=windows` and for Linux Docker builds, add `--config=docker`.
+
 # to add support for `--spawn_strategy=docker`
-register_execution_platforms("//platforms:docker")
+# register_execution_platforms(
+#     "//platforms:docker",
+#     "//platforms:windows"
+# )

--- a/defs/defs.bzl
+++ b/defs/defs.bzl
@@ -15,5 +15,6 @@ def custom_go_test(
         data = data,
         deps = deps,
         tags = [tag],
+        # running `bazel test --config=windows //tests:all` on Windows would skip these tests
         target_compatible_with = ["@platforms//os:linux"],
     )


### PR DESCRIPTION
Add support to run project tests in Windows by requesting Windows platform on demand.