### PR TITLE
bazel: add a separate config for remote Buildbuddy builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,14 +22,14 @@ common:docker --experimental_enable_docker_sandbox
 common:docker --experimental_docker_image="golang:1.22"
 
 # BuildBuddy remote cache configuration (read&write)
-build --bes_results_url=https://app.buildbuddy.io/invocation/
-build --bes_backend=grpcs://remote.buildbuddy.io
-build --remote_cache=grpcs://remote.buildbuddy.io
-build --remote_timeout=3600
+build:bb --bes_results_url=https://app.buildbuddy.io/invocation/
+build:bb --bes_backend=grpcs://remote.buildbuddy.io
+build:bb --remote_cache=grpcs://remote.buildbuddy.io
+build:bb --remote_timeout=3600
 
 # BuildBuddy remote cache/execution recommended flags 
-build --remote_cache_compression
-build --experimental_remote_cache_compression_threshold=100
-build --nolegacy_important_outputs
+build:bb --remote_cache_compression
+build:bb --experimental_remote_cache_compression_threshold=100
+build:bb --nolegacy_important_outputs
 
 try-import %workspace%/.bazelrc.ci

--- a/.buildkite/build-bazel.sh
+++ b/.buildkite/build-bazel.sh
@@ -12,7 +12,7 @@ echo 'Buildifier'
 bazel run //:buildifier-check
 bazel run //:buildifier
 echo 'gofmt'
-output=$(bazel run @rules_go//go -- fmt .) && [[ -n "$output" ]] && echo "$output" && exit 1 || echo "No formatting required"
+output=$(bazel run @rules_go//go -- fmt ./...) && [[ -n "$output" ]] && echo "$output" && exit 1 || echo "No formatting required"
 
 echo '--- Run'
 bazel build //... && bazel-bin/dg-query_/dg-query dependencies --dg="examples/dg-real.json" foo.py spam.py

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,8 @@ run-go:
 	go run main.go dependencies --dg="examples/dg-real.json" foo.py spam.py
 
 build-bazel:
-	.buildkite/build-bazel.sh
+	bazel run //:gazelle
+	bazel run //:buildifier
+	bazel run @rules_go//go -- fmt ./...
+	bazel build //...
+	bazel test //...

--- a/build-support/create-bazelrc-ci.sh
+++ b/build-support/create-bazelrc-ci.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 echo "common --show_timestamps" > .bazelrc.ci
+echo "common --config=bb" >> .bazelrc.ci
 echo "build --build_metadata=ROLE=CI" >> .bazelrc.ci
 
 # this secret is declared in Buildkite secrets
@@ -12,4 +13,4 @@ else
     # runs locally and the api key should be available via the environment variable
     BUILD_BUDDY_API_KEY=${BUILD_BUDDY_API_KEY}
 fi
-echo "build --remote_header=x-buildbuddy-api-key=$BUILD_BUDDY_API_KEY" >> .bazelrc.ci
+echo "build:bb --remote_header=x-buildbuddy-api-key=$BUILD_BUDDY_API_KEY" >> .bazelrc.ci

--- a/build.md
+++ b/build.md
@@ -1,0 +1,38 @@
+# Build
+
+This document provides an overview of the build process. 
+
+## Bazel
+
+Bazel is used to build the project locally and in CI. However, the project can still
+be built with native Go tooling. For local builds, run `make build-go` or `make build-bazel`
+to build with Go and Bazel, respectively. The project originally used `WORKSPACE` based build, 
+but then was migrated to Bzlmod.
+
+For CI, a few scripts to be run in Buildkite exist.
+
+* `.buildkite/build-go.sh`: build on Buildkite agent using native Go tooling
+* `.buildkite/build-bazel.sh`: build on Buildkite agent using Bazel
+* `.buildkite/build-bazel-docker.sh`: build in a Docker container (using `--spawn_strategy=docker`, see the [docs](https://bazel.build/reference/command-line-reference#build-flag--spawn_strategy))
+* `.buildkite/build-bazel-remote.sh`: build remotely on BuildBuddy (on their agent)
+
+The `defs` directory contains example of macros and loading members of `.bzl` files.
+
+The `platforms` directory contains examples on how to:
+* build CGo code
+* run tests on Windows 
+* build in a custom Docker container
+
+Build specific documentation can be found at the `.buildkite` directory's Shell scripts 
+and files with build metadata such as `MODULE.bazel` and `BUILD.bazel` files.
+
+## Release
+
+A GitHub release is produced by running the following commands
+
+```shell
+git tag v0.X.0
+git push --tags
+```
+
+which triggers the `goreleaser` action in `.github/workflows/release.yml`.


### PR DESCRIPTION
Minor tidy ups around remote BB builds. Added document describing the build process, too.