### PR TITLE
bazel: convert legacy macros to symbolic macros

### DIFF
--- a/defs/constants.bzl
+++ b/defs/constants.bzl
@@ -1,4 +1,4 @@
 """Constants to be used by rules."""
 # This file is not formatted with Buildifier on purpose to allow custom formatting
-EXAMPLES_DG_JSON="examples/dg.json"
-TRANSITIVE_REDUCTION_DG_JSON="examples/dg-transitive-reduction.json"
+EXAMPLES_DG_JSON="//tests/examples:dg.json"
+TRANSITIVE_REDUCTION_DG_JSON="//tests/examples:dg-transitive-reduction.json"

--- a/defs/defs.bzl
+++ b/defs/defs.bzl
@@ -3,18 +3,24 @@
 load("@rules_go//go:def.bzl", "go_test")
 load("//:defs/constants.bzl", "EXAMPLES_DG_JSON", "TRANSITIVE_REDUCTION_DG_JSON")
 
-def custom_go_test(
-        name,
-        srcs,
-        tag,
-        data = [EXAMPLES_DG_JSON, TRANSITIVE_REDUCTION_DG_JSON],
-        deps = ["//cmd", "@com_github_stretchr_testify//assert", "@com_github_spf13_cast//:cast"]):
+def _custom_go_test_impl(name, visibility, srcs, data, deps, tags):
     go_test(
         name = name,
+        data = (data or []) + [EXAMPLES_DG_JSON, TRANSITIVE_REDUCTION_DG_JSON],
+        deps = (deps or []) + ["//cmd", "@com_github_stretchr_testify//assert", "@com_github_spf13_cast//:cast"],
         srcs = srcs,
-        data = data,
-        deps = deps,
-        tags = [tag],
         # running `bazel test --config=windows //tests:all` on Windows would skip these tests
+        tags = tags,
         target_compatible_with = ["@platforms//os:linux"],
+        visibility = visibility,
     )
+
+custom_go_test = macro(
+    attrs = {
+        "data": attr.label_list(configurable = False),
+        "deps": attr.label_list(configurable = False),
+        "srcs": attr.label_list(configurable = False, mandatory = True),
+        "tags": attr.string_list(configurable = False, mandatory = True),
+    },
+    implementation = _custom_go_test_impl,
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,11 +4,11 @@ load("//:defs/defs.bzl", "custom_go_test")
 custom_go_test(
     name = "dg-query_integration_test",
     srcs = ["main_cli_test.go"],
-    tag = "integration",
+    tags = ["integration"],
 )
 
 custom_go_test(
     name = "dg-query_performance_test",
     srcs = ["main_perf_test.go"],
-    tag = "performance",
+    tags = ["performance"],
 )

--- a/tests/examples/BUILD.bazel
+++ b/tests/examples/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.json"]))


### PR DESCRIPTION
See https://bazel.build/extending/macros